### PR TITLE
fix: 站点域名统一为正式域名 lune.ltd

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ English | [中文说明 (Chinese)](./README.zh-CN.md)
 
 Source code for my personal website and blog, built with Vite + React and deployed to GitHub Pages.
 
-Live site: <https://junedrinleng.github.io/>
+Live site: <https://lune.ltd/>
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 这是我的个人网站与博客项目源码，基于 Vite + React 构建，并部署在 GitHub Pages。
 
-在线地址：<https://junedrinleng.github.io/>
+在线地址：<https://lune.ltd/>
 
 ## 项目功能
 

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://junedrinleng.github.io/sitemap.xml
+Sitemap: https://lune.ltd/sitemap.xml

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 const DIST = resolve(ROOT, 'dist');
-const SITE_URL = 'https://junedrinleng.github.io';
+const SITE_URL = 'https://lune.ltd';
 
 // Public static routes from src/app/routes.ts. /blog is gated behind auth, so
 // it and individual posts are intentionally excluded from the sitemap.

--- a/worker/README.md
+++ b/worker/README.md
@@ -66,7 +66,7 @@ wrangler secret put PRIVATE_REPO_TOKEN     # 第 2 步的 fine-grained PAT
 PRIVATE_REPO        = "JuneDrinleng/notes"
 PRIVATE_REPO_BRANCH = "main"
 ALLOWED_OWNER       = "JuneDrinleng"
-ALLOWED_ORIGINS     = "https://junedrinleng.github.io,http://localhost:5173"
+ALLOWED_ORIGINS     = "https://lune.ltd,http://localhost:5173"
 ```
 
 > `PRIVATE_REPO_TOKEN` 只存在于 Worker，永不下发到浏览器。
@@ -103,7 +103,7 @@ git commit -m "chore: move blog markdown to private repo"
 - [ ] **PRIVATE_REPO_TOKEN** 能读私有仓库（fine-grained Contents:Read 或经典 `repo`；`public_repo` 不够）。
 - [ ] **PRIVATE_REPO_BRANCH** 与 notes 默认分支一致（默认按 `main`；若是 `master` 等需显式设置）。
 - [ ] **ALLOWED_OWNER** 为精确大小写 `JuneDrinleng`（比较区分大小写）。
-- [ ] **ALLOWED_ORIGINS** 含站点精确源 `https://junedrinleng.github.io`（本地开发可加 `http://localhost:5173`；不要带结尾斜杠）。
+- [ ] **ALLOWED_ORIGINS** 含站点精确源 `https://lune.ltd`（本地开发可加 `http://localhost:5173`；不要带结尾斜杠）。
 - [ ] `/api/posts` 路由确实部署在前端请求的 Worker URL 上（默认 `https://junedrinlengblog.zhuzilan520.workers.dev`，否则设 `VITE_BLOG_API`）。
 - [ ] notes 仓库目录精确为 `posts/` 和 `posts-en/`（大小写敏感）。
 

--- a/worker/blog-api.js
+++ b/worker/blog-api.js
@@ -31,7 +31,7 @@
  *   PRIVATE_REPO_BRANCH e.g. "main"  (optional, defaults to "main")
  *   ALLOWED_OWNER       e.g. "JuneDrinleng"  (exact canonical login casing)
  *   ALLOWED_ORIGINS     comma-separated, e.g.
- *                       "https://junedrinleng.github.io,http://localhost:5173"
+ *                       "https://lune.ltd,http://localhost:5173"
  *
  * Repo layout expected in the private repo:
  *   posts/*.md       (zh)


### PR DESCRIPTION
仓库内多处仍硬编码 GitHub Pages 原始域名 junedrinleng.github.io， 而站点实际通过自定义域名 lune.ltd 访问（见 public/CNAME）。统一对齐：

- scripts/generate-sitemap.mjs: SITE_URL → https://lune.ltd（sitemap 链接）
- robots.txt: Sitemap 指向 → https://lune.ltd/sitemap.xml
- worker/blog-api.js & worker/README.md: ALLOWED_ORIGINS 示例/检查项 → lune.ltd
- README.md & README.zh-CN.md: Live site 链接 → lune.ltd